### PR TITLE
se agrega .idea/deploymentTargetSelector.xml

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-09-11T20:46:02.198852500Z">
+        <DropdownSelection timestamp="2025-09-22T01:02:31.484640900Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="PhysicalDevice" identifier="serial=3300a85c6619c4d1" />


### PR DESCRIPTION
chore(git): ignorar archivos de configuración de Android Studio

- Se elimina del repositorio la configuración de selección de dispositivos en `.idea/`.
- Se actualiza `.gitignore` para excluir `.idea/` y evitar que estos cambios locales se suban en futuros commits.
